### PR TITLE
🧹 Use prettier to format json

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -62,12 +62,7 @@
           }
         }
       },
-      "required": [
-        "type",
-        "metadata",
-        "title",
-        "children"
-      ]
+      "required": ["type", "metadata", "title", "children"]
     },
     "Heading": {
       "title": "Heading",
@@ -108,13 +103,7 @@
           }
         }
       },
-      "required": [
-        "type",
-        "level",
-        "children",
-        "classes",
-        "data"
-      ]
+      "required": ["type", "level", "children", "classes", "data"]
     },
     "Inline": {
       "title": "Inline",
@@ -161,12 +150,7 @@
           }
         }
       },
-      "required": [
-        "type",
-        "children",
-        "classes",
-        "data"
-      ]
+      "required": ["type", "children", "classes", "data"]
     },
     "Strong": {
       "title": "Strong",
@@ -201,12 +185,7 @@
           }
         }
       },
-      "required": [
-        "type",
-        "children",
-        "classes",
-        "data"
-      ]
+      "required": ["type", "children", "classes", "data"]
     },
     "Text": {
       "title": "Text",
@@ -238,12 +217,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "value",
-        "classes",
-        "data"
-      ]
+      "required": ["type", "value", "classes", "data"]
     }
   },
   "$ref": "#/definitions/Document"

--- a/scripts/lib/generate-json.ts
+++ b/scripts/lib/generate-json.ts
@@ -9,6 +9,7 @@
 
 import { writeFileSync } from "fs";
 import { join } from "path";
+import prettier from "prettier";
 import { loadMergedSchema } from "./schema.js";
 
 const OUTPUT_PATH = join(import.meta.dirname, "../../schema/schema.json");
@@ -16,6 +17,10 @@ const OUTPUT_PATH = join(import.meta.dirname, "../../schema/schema.json");
 export async function generateJson(): Promise<void> {
   const schema = loadMergedSchema();
   const json = JSON.stringify(schema, null, 2);
-  writeFileSync(OUTPUT_PATH, json + "\n");
+  const formatted = await prettier.format(json, {
+    parser: "json",
+    filepath: OUTPUT_PATH,
+  });
+  writeFileSync(OUTPUT_PATH, formatted);
   console.log(`Generated ${OUTPUT_PATH}`);
 }


### PR DESCRIPTION
In #19 noticed that fixing a typo failed tests, and then created a commit to change the JSON format. This updates to using prettier to format the json (which is indented differently and fails CI).

The two should now be consistent.