### PR TITLE
tests(lexicon): fix for move

### DIFF
--- a/packages/oxa-core/src/convert.test.ts
+++ b/packages/oxa-core/src/convert.test.ts
@@ -31,7 +31,7 @@ const lexiconFiles = {
   },
   document: {
     id: "pub.oxa.document",
-    path: resolve(REPO_ROOT, "lexicon/document/document.json"),
+    path: resolve(REPO_ROOT, "lexicon/document.json"),
   },
 } as const;
 


### PR DESCRIPTION
Fix for failing test caused by moving the lexicon document.