### PR TITLE
Add executable code nodes `CodeCell` and `CodeExpr` 

### DIFF
--- a/docs/schema/block.md
+++ b/docs/schema/block.md
@@ -6,4 +6,4 @@
 Union of all block content types.
 
 
-Union of: @oxa:code, @oxa:heading, @oxa:paragraph, @oxa:reference, @oxa:thematicbreak
+Union of: @oxa:code, @oxa:codecell, @oxa:heading, @oxa:paragraph, @oxa:reference, @oxa:thematicbreak

--- a/docs/schema/codecell.md
+++ b/docs/schema/codecell.md
@@ -1,0 +1,51 @@
+(oxa:codecell)=
+
+## CodeCell
+
+
+An executable block of code that can produce outputs.
+
+
+__type__: _string_, ("CodeCell")
+
+: The type discriminator for CodeCell nodes.
+
+__id__: __string__
+
+: A unique identifier for the node.
+
+__classes__: __array__ ("string")
+
+: A list of class names for styling or semantics.
+
+__data__: __object__
+
+: Arbitrary key-value data attached to the node.
+
+__code__: __string__
+
+: The source code to execute.
+
+__language__: __string__
+
+: The programming language identifier for the code.
+
+__isEchoed__: __boolean__
+
+: Whether the source code is displayed to readers.
+
+__isHidden__: __boolean__
+
+: Whether outputs are hidden from readers.
+
+### Example
+
+`````{tab-set}
+````{tab-item} OXA
+:sync: oxa
+```json
+{"type":"CodeCell","language":"python","code":"x = 1\nx","isEchoed":true}
+```
+````
+
+`````

--- a/docs/schema/codeexpr.md
+++ b/docs/schema/codeexpr.md
@@ -1,0 +1,43 @@
+(oxa:codeexpr)=
+
+## CodeExpr
+
+
+An executable expression embedded within prose.
+
+
+__type__: _string_, ("CodeExpr")
+
+: The type discriminator for CodeExpr nodes.
+
+__id__: __string__
+
+: A unique identifier for the node.
+
+__classes__: __array__ ("string")
+
+: A list of class names for styling or semantics.
+
+__data__: __object__
+
+: Arbitrary key-value data attached to the node.
+
+__code__: __string__
+
+: The expression to evaluate.
+
+__language__: __string__
+
+: The programming language identifier for the expression.
+
+### Example
+
+`````{tab-set}
+````{tab-item} OXA
+:sync: oxa
+```json
+{"type":"CodeExpr","language":"python","code":"len(df)"}
+```
+````
+
+`````

--- a/docs/schema/inline.md
+++ b/docs/schema/inline.md
@@ -6,4 +6,4 @@
 Union of all inline content types.
 
 
-Union of: @oxa:cite, @oxa:citegroup, @oxa:text, @oxa:emphasis, @oxa:inlinecode, @oxa:strong, @oxa:subscript, @oxa:superscript
+Union of: @oxa:cite, @oxa:citegroup, @oxa:text, @oxa:emphasis, @oxa:codeexpr, @oxa:inlinecode, @oxa:strong, @oxa:subscript, @oxa:superscript

--- a/lexicon/blocks/defs.json
+++ b/lexicon/blocks/defs.json
@@ -45,6 +45,39 @@
         "value"
       ]
     },
+    "codeCell": {
+      "type": "object",
+      "description": "An executable block of code that can produce outputs.",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "data": {
+          "type": "unknown"
+        },
+        "code": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        },
+        "isEchoed": {
+          "type": "boolean"
+        },
+        "isHidden": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "code"
+      ]
+    },
     "heading": {
       "type": "object",
       "description": "A heading with a level and inline content.",
@@ -167,6 +200,7 @@
       "closed": false,
       "refs": [
         "#code",
+        "#codeCell",
         "#heading",
         "#paragraph",
         "#reference",

--- a/lexicon/richtext/facet.json
+++ b/lexicon/richtext/facet.json
@@ -23,6 +23,7 @@
               "#cite",
               "#citeGroup",
               "#emphasis",
+              "#codeExpr",
               "#inlineCode",
               "#strong",
               "#subscript",
@@ -98,6 +99,21 @@
     "emphasis": {
       "type": "object",
       "description": "Emphasized content (typically italicized)."
+    },
+    "codeExpr": {
+      "type": "object",
+      "description": "An executable expression embedded within prose.",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "code"
+      ]
     },
     "inlineCode": {
       "type": "object",

--- a/packages/oxa-conformance/cases/block/codecell-basic.json
+++ b/packages/oxa-conformance/cases/block/codecell-basic.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schemas/test-case.schema.json",
+  "title": "Basic code cell",
+  "description": "An executable code block with source code and language",
+  "category": "block",
+  "formats": {
+    "oxa": {
+      "type": "CodeCell",
+      "language": "python",
+      "code": "x = 1\nx",
+      "isEchoed": true
+    }
+  }
+}

--- a/packages/oxa-conformance/cases/inline/codeexpr-basic.json
+++ b/packages/oxa-conformance/cases/inline/codeexpr-basic.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/test-case.schema.json",
+  "title": "Basic code expression",
+  "description": "An executable inline expression with source code and language",
+  "category": "inline",
+  "formats": {
+    "oxa": {
+      "type": "CodeExpr",
+      "language": "python",
+      "code": "len(df)"
+    }
+  }
+}

--- a/packages/oxa-conformance/manifest.json
+++ b/packages/oxa-conformance/manifest.json
@@ -27,6 +27,12 @@
       "nodeTypes": ["CiteGroup", "Cite"]
     },
     {
+      "id": "codeexpr-basic",
+      "path": "cases/inline/codeexpr-basic.json",
+      "category": "inline",
+      "nodeTypes": ["CodeExpr"]
+    },
+    {
       "id": "emphasis-basic",
       "path": "cases/inline/emphasis-basic.json",
       "category": "inline",
@@ -43,6 +49,12 @@
       "path": "cases/inline/text-basic.json",
       "category": "inline",
       "nodeTypes": ["Text"]
+    },
+    {
+      "id": "codecell-basic",
+      "path": "cases/block/codecell-basic.json",
+      "category": "block",
+      "nodeTypes": ["CodeCell"]
     },
     {
       "id": "heading-basic",

--- a/packages/oxa-core/src/convert.test.ts
+++ b/packages/oxa-core/src/convert.test.ts
@@ -39,6 +39,7 @@ const facetFragments = [
   "cite",
   "citeGroup",
   "emphasis",
+  "codeExpr",
   "inlineCode",
   "strong",
   "subscript",
@@ -47,6 +48,7 @@ const facetFragments = [
 
 const documentBlockRefs = [
   "#code",
+  "#codeCell",
   "#heading",
   "#paragraph",
   "#reference",
@@ -56,6 +58,7 @@ const documentBlockRefs = [
 const requiredDocumentDefs = [
   "richText",
   "code",
+  "codeCell",
   "paragraph",
   "heading",
   "reference",
@@ -75,6 +78,18 @@ type TestTextNode = {
   value: string;
 };
 
+type TestInlineCodeNode = {
+  type: "InlineCode";
+  value: string;
+  language?: string;
+};
+
+type TestCodeExprNode = {
+  type: "CodeExpr";
+  code: string;
+  language?: string;
+};
+
 type TestFormattingNode = {
   type: "Strong" | "Emphasis";
   children: TestInlineNode[];
@@ -83,7 +98,11 @@ type TestFormattingNode = {
   data?: Record<string, unknown>;
 };
 
-type TestInlineNode = TestTextNode | TestFormattingNode;
+type TestInlineNode =
+  | TestTextNode
+  | TestInlineCodeNode
+  | TestCodeExprNode
+  | TestFormattingNode;
 
 type TestParagraphNode = {
   type: "Paragraph";
@@ -472,6 +491,30 @@ describe("mapBlock", () => {
       facets: [],
     });
   });
+
+  it("maps a CodeCell block preserving source fields and visibility flags", async () => {
+    await expect(
+      map({
+        type: "CodeCell",
+        id: "cell-1",
+        classes: ["analysis"],
+        data: { kernel: "python3" },
+        language: "python",
+        code: "x = 1\nx",
+        isEchoed: false,
+        isHidden: true,
+      }),
+    ).resolves.toEqual({
+      $type: "pub.oxa.blocks.defs#codeCell",
+      id: "cell-1",
+      classes: ["analysis"],
+      data: { kernel: "python3" },
+      language: "python",
+      code: "x = 1\nx",
+      isEchoed: false,
+      isHidden: true,
+    });
+  });
 });
 
 describe("oxaToAtproto", () => {
@@ -713,6 +756,55 @@ describe("flattenInlines", () => {
     await expect(flatten([])).resolves.toEqual({
       text: "",
       facets: [],
+    });
+  });
+
+  it("emits an InlineCode facet with source value and language", async () => {
+    const richText = await flatten([
+      text("Run "),
+      { type: "InlineCode", value: "npm test", language: "bash" },
+      text("."),
+    ]);
+
+    expect(richText).toEqual({
+      text: "Run npm test.",
+      facets: [
+        {
+          index: { byteStart: 4, byteEnd: 12 },
+          features: [
+            {
+              $type: "pub.oxa.richtext.facet#inlineCode",
+              value: "npm test",
+              language: "bash",
+            },
+            { $type: "pub.leaflet.richtext.facet#code" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("flattens CodeExpr source and emits a CodeExpr facet", async () => {
+    const richText = await flatten([
+      text("Rows: "),
+      { type: "CodeExpr", code: "len(df)", language: "python" },
+      text("."),
+    ]);
+
+    expect(richText).toEqual({
+      text: "Rows: len(df).",
+      facets: [
+        {
+          index: { byteStart: 6, byteEnd: 13 },
+          features: [
+            {
+              $type: "pub.oxa.richtext.facet#codeExpr",
+              code: "len(df)",
+              language: "python",
+            },
+          ],
+        },
+      ],
     });
   });
 

--- a/packages/oxa-core/src/convert.ts
+++ b/packages/oxa-core/src/convert.ts
@@ -20,6 +20,15 @@ type InlineCodeNode = {
   data?: Record<string, unknown>;
 };
 
+type CodeExprNode = {
+  type: "CodeExpr";
+  code: string;
+  language?: string;
+  id?: string;
+  classes?: string[];
+  data?: Record<string, unknown>;
+};
+
 type FormattingNode = {
   type: "Strong" | "Emphasis" | "Superscript" | "Subscript";
   children: InlineNode[];
@@ -55,6 +64,7 @@ type CiteGroupNode = {
 type InlineNode =
   | TextNode
   | InlineCodeNode
+  | CodeExprNode
   | FormattingNode
   | CiteNode
   | CiteGroupNode;
@@ -82,6 +92,14 @@ type CodeNode = BlockNodeBase & {
   language?: string;
 };
 
+type CodeCellNode = BlockNodeBase & {
+  type: "CodeCell";
+  code: string;
+  language?: string;
+  isEchoed?: boolean;
+  isHidden?: boolean;
+};
+
 type ThematicBreakNode = BlockNodeBase & {
   type: "ThematicBreak";
 };
@@ -101,6 +119,7 @@ type BlockNode =
   | ParagraphNode
   | HeadingNode
   | CodeNode
+  | CodeCellNode
   | ThematicBreakNode
   | ReferenceNode
   | UnknownBlockNode;
@@ -147,6 +166,14 @@ type AtprotoCode = BlockNodeBase & {
   language?: string;
 };
 
+type AtprotoCodeCell = BlockNodeBase & {
+  $type: "pub.oxa.blocks.defs#codeCell";
+  code: string;
+  language?: string;
+  isEchoed?: boolean;
+  isHidden?: boolean;
+};
+
 type AtprotoThematicBreak = BlockNodeBase & {
   $type: "pub.oxa.blocks.defs#thematicBreak";
 };
@@ -162,6 +189,7 @@ type AtprotoBlock =
   | AtprotoParagraph
   | AtprotoHeading
   | AtprotoCode
+  | AtprotoCodeCell
   | AtprotoThematicBreak
   | AtprotoReference;
 
@@ -179,16 +207,24 @@ type OxaToAtprotoOptions = {
 
 type FormattingPropertyName = "id" | "classes" | "data";
 type BlockPropertyName = keyof BlockNodeBase;
+type InlineMetadataNode = {
+  type: string;
+  id?: string;
+  classes?: string[];
+  data?: Record<string, unknown>;
+};
 type KnownBlockNode =
   | ParagraphNode
   | HeadingNode
   | CodeNode
+  | CodeCellNode
   | ThematicBreakNode
   | ReferenceNode;
 
 const facetFeatureTypes = {
   Cite: "pub.oxa.richtext.facet#cite",
   CiteGroup: "pub.oxa.richtext.facet#citeGroup",
+  CodeExpr: "pub.oxa.richtext.facet#codeExpr",
   Strong: "pub.oxa.richtext.facet#strong",
   Emphasis: "pub.oxa.richtext.facet#emphasis",
   Superscript: "pub.oxa.richtext.facet#superscript",
@@ -241,6 +277,7 @@ const citeFeaturePropertyNames = [
 const paragraphType = "pub.oxa.blocks.defs#paragraph" as const;
 const headingType = "pub.oxa.blocks.defs#heading" as const;
 const codeType = "pub.oxa.blocks.defs#code" as const;
+const codeCellType = "pub.oxa.blocks.defs#codeCell" as const;
 const thematicBreakType = "pub.oxa.blocks.defs#thematicBreak" as const;
 const referenceType = "pub.oxa.blocks.defs#reference" as const;
 
@@ -254,13 +291,35 @@ function getCurrentByteOffset(richText: RichText): number {
   return byteLength(richText.text);
 }
 
+function createInlineFeature(
+  node: FormattingNode | InlineCodeNode | CodeExprNode,
+): FacetFeature {
+  const oxaType = facetFeatureTypes[node.type];
+
+  if (node.type === "InlineCode") {
+    return {
+      $type: oxaType,
+      ...copyDefinedProperties(node, ["value", "language"] as const),
+    };
+  }
+
+  if (node.type === "CodeExpr") {
+    return {
+      $type: oxaType,
+      ...copyDefinedProperties(node, ["code", "language"] as const),
+    };
+  }
+
+  return { $type: oxaType };
+}
+
 function createFacet(
-  node: FormattingNode | InlineCodeNode,
+  node: FormattingNode | InlineCodeNode | CodeExprNode,
   byteStart: number,
   byteEnd: number,
 ): Facet {
   const oxaType = facetFeatureTypes[node.type];
-  const features: FacetFeature[] = [{ $type: oxaType }];
+  const features: FacetFeature[] = [createInlineFeature(node)];
 
   const compat = compatibleFeatures[oxaType];
   if (compat) {
@@ -311,7 +370,7 @@ function createCiteGroupFacet(
 }
 
 function getDroppedFormattingProperties(
-  node: FormattingNode,
+  node: InlineMetadataNode,
 ): FormattingPropertyName[] {
   return formattingPropertyNames.filter(
     (propertyName) => node[propertyName] !== undefined,
@@ -335,7 +394,10 @@ function copyDefinedProperties<T extends object, K extends keyof T>(
   return props;
 }
 
-function warnDroppedProperties(session: Session, node: FormattingNode): void {
+function warnDroppedProperties(
+  session: Session,
+  node: InlineMetadataNode,
+): void {
   const dropped = getDroppedFormattingProperties(node);
 
   if (dropped.length === 0) {
@@ -358,9 +420,18 @@ function flattenNode(
   }
 
   if (node.type === "InlineCode") {
-    warnDroppedProperties(session, node as unknown as FormattingNode);
+    warnDroppedProperties(session, node);
     const byteStart = getCurrentByteOffset(richText);
     richText.text += node.value;
+    const byteEnd = getCurrentByteOffset(richText);
+    richText.facets.push(createFacet(node, byteStart, byteEnd));
+    return;
+  }
+
+  if (node.type === "CodeExpr") {
+    warnDroppedProperties(session, node);
+    const byteStart = getCurrentByteOffset(richText);
+    richText.text += node.code;
     const byteEnd = getCurrentByteOffset(richText);
     richText.facets.push(createFacet(node, byteStart, byteEnd));
     return;
@@ -506,6 +577,7 @@ function isKnownBlock(block: BlockNode): block is KnownBlockNode {
     block.type === "Paragraph" ||
     block.type === "Heading" ||
     block.type === "Code" ||
+    block.type === "CodeCell" ||
     block.type === "ThematicBreak" ||
     block.type === "Reference"
   );
@@ -525,6 +597,17 @@ function mapCodeBlock(block: CodeNode): AtprotoCode {
     result.language = block.language;
   }
   return result;
+}
+
+function mapCodeCell(block: CodeCellNode): AtprotoCodeCell {
+  return {
+    $type: codeCellType,
+    ...copyBlockProps(block),
+    code: block.code,
+    ...(block.language !== undefined ? { language: block.language } : {}),
+    ...(block.isEchoed !== undefined ? { isEchoed: block.isEchoed } : {}),
+    ...(block.isHidden !== undefined ? { isHidden: block.isHidden } : {}),
+  };
 }
 
 function mapThematicBreak(block: ThematicBreakNode): AtprotoThematicBreak {
@@ -551,6 +634,10 @@ function mapReference(
 function mapKnownBlock(session: Session, block: KnownBlockNode): AtprotoBlock {
   if (block.type === "Code") {
     return mapCodeBlock(block);
+  }
+
+  if (block.type === "CodeCell") {
+    return mapCodeCell(block);
   }
 
   if (block.type === "ThematicBreak") {

--- a/packages/oxa-core/src/validate.test.ts
+++ b/packages/oxa-core/src/validate.test.ts
@@ -74,6 +74,26 @@ const validDocumentWithCitations = {
   ],
 };
 
+const validDocumentWithExecutableCode = {
+  type: "Document",
+  children: [
+    {
+      type: "CodeCell",
+      language: "python",
+      code: "x = 1\nx",
+      isEchoed: true,
+      isHidden: false,
+    },
+    {
+      type: "Paragraph",
+      children: [
+        { type: "Text", value: "Rows: " },
+        { type: "CodeExpr", language: "python", code: "len(df)" },
+      ],
+    },
+  ],
+};
+
 describe("validate", () => {
   it("returns valid for correct Document", () => {
     const result = validate(validDocument);
@@ -91,6 +111,57 @@ describe("validate", () => {
     const result = validate(validDocumentWithCitations);
     expect(result.valid).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it("returns valid for Document with executable code nodes", () => {
+    const result = validate(validDocumentWithExecutableCode);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("validates CodeCell against its specific type", () => {
+    const result = validate(
+      {
+        type: "CodeCell",
+        language: "python",
+        code: "x = 1\nx",
+        isEchoed: false,
+        isHidden: true,
+      },
+      { type: "CodeCell" },
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects CodeCell without required code", () => {
+    const result = validate(
+      {
+        type: "CodeCell",
+        language: "python",
+      },
+      { type: "CodeCell" },
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it("validates CodeExpr against its specific type", () => {
+    const result = validate(
+      {
+        type: "CodeExpr",
+        language: "python",
+        code: "len(df)",
+      },
+      { type: "CodeExpr" },
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects CodeExpr as a block child", () => {
+    const result = validate({
+      type: "Document",
+      children: [{ type: "CodeExpr", code: "len(df)" }],
+    });
+    expect(result.valid).toBe(false);
   });
 
   it("validates Cite against its specific type", () => {
@@ -323,6 +394,8 @@ describe("getTypeNames", () => {
     const types = getTypeNames();
     expect(types).toContain("Cite");
     expect(types).toContain("CiteGroup");
+    expect(types).toContain("CodeCell");
+    expect(types).toContain("CodeExpr");
     expect(types).toContain("Document");
     expect(types).toContain("Heading");
     expect(types).toContain("Paragraph");

--- a/packages/oxa-react/src/defaults/CodeCell.tsx
+++ b/packages/oxa-react/src/defaults/CodeCell.tsx
@@ -1,0 +1,29 @@
+import type { OxaNode } from "../types";
+
+export function CodeCellRenderer({
+  node,
+  className,
+}: {
+  node: OxaNode & {
+    code?: string;
+    language?: string;
+    isEchoed?: boolean;
+  };
+  className?: string;
+}) {
+  if (node.isEchoed !== true) return null;
+
+  return (
+    <pre
+      id={node.id}
+      className={
+        className ??
+        "bg-slate-100 rounded-lg p-4 overflow-x-auto mb-3 text-sm"
+      }
+    >
+      <code className={node.language ? `language-${node.language}` : undefined}>
+        {node.code}
+      </code>
+    </pre>
+  );
+}

--- a/packages/oxa-react/src/defaults/CodeExpr.tsx
+++ b/packages/oxa-react/src/defaults/CodeExpr.tsx
@@ -1,0 +1,20 @@
+import type { OxaNode } from "../types";
+
+export function CodeExprRenderer({
+  node,
+  className,
+}: {
+  node: OxaNode & { code?: string };
+  className?: string;
+}) {
+  return (
+    <code
+      className={
+        className ??
+        "bg-slate-100 rounded px-1.5 py-0.5 text-sm font-mono text-pink-600"
+      }
+    >
+      {node.code}
+    </code>
+  );
+}

--- a/packages/oxa-react/src/defaults/index.ts
+++ b/packages/oxa-react/src/defaults/index.ts
@@ -3,6 +3,8 @@ import { DocumentRenderer } from "./Document";
 import { HeadingRenderer } from "./Heading";
 import { ParagraphRenderer } from "./Paragraph";
 import { CodeRenderer } from "./Code";
+import { CodeCellRenderer } from "./CodeCell";
+import { CodeExprRenderer } from "./CodeExpr";
 import { ThematicBreakRenderer } from "./ThematicBreak";
 import { TextRenderer } from "./Text";
 import { EmphasisRenderer } from "./Emphasis";
@@ -22,6 +24,8 @@ export const defaultRenderers: NodeRenderers = {
   Paragraph: ParagraphRenderer,
   Reference: ReferenceRenderer,
   Code: CodeRenderer,
+  CodeCell: CodeCellRenderer,
+  CodeExpr: CodeExprRenderer,
   ThematicBreak: ThematicBreakRenderer,
   Text: TextRenderer,
   Emphasis: EmphasisRenderer,

--- a/packages/oxa-types-py/src/oxa_types/__init__.py
+++ b/packages/oxa-types-py/src/oxa_types/__init__.py
@@ -101,6 +101,55 @@ class Code(BaseModel):
     value: str = Field(description="The code content.")
 
 
+class CodeCell(BaseModel):
+    """An executable block of code that can produce outputs."""
+
+    model_config = ConfigDict(strict=True)
+
+    type: Literal["CodeCell"] = "CodeCell"
+    id: str | None = Field(
+        default=None, description="A unique identifier for the node."
+    )
+    classes: list[str] | None = Field(
+        default=None, description="A list of class names for styling or semantics."
+    )
+    data: dict[str, Any] | None = Field(
+        default=None, description="Arbitrary key-value data attached to the node."
+    )
+    code: str = Field(description="The source code to execute.")
+    language: str | None = Field(
+        default=None, description="The programming language identifier for the code."
+    )
+    isEchoed: bool | None = Field(
+        default=None, description="Whether the source code is displayed to readers."
+    )
+    isHidden: bool | None = Field(
+        default=None, description="Whether outputs are hidden from readers."
+    )
+
+
+class CodeExpr(BaseModel):
+    """An executable expression embedded within prose."""
+
+    model_config = ConfigDict(strict=True)
+
+    type: Literal["CodeExpr"] = "CodeExpr"
+    id: str | None = Field(
+        default=None, description="A unique identifier for the node."
+    )
+    classes: list[str] | None = Field(
+        default=None, description="A list of class names for styling or semantics."
+    )
+    data: dict[str, Any] | None = Field(
+        default=None, description="Arbitrary key-value data attached to the node."
+    )
+    code: str = Field(description="The expression to evaluate.")
+    language: str | None = Field(
+        default=None,
+        description="The programming language identifier for the expression.",
+    )
+
+
 class Document(BaseModel):
     """A document with metadata, title, and block content."""
 
@@ -320,14 +369,24 @@ class ThematicBreak(BaseModel):
 
 # Union of all block content types.
 Block = Annotated[
-    Union[Code, Heading, Paragraph, Reference, ThematicBreak],
+    Union[Code, CodeCell, Heading, Paragraph, Reference, ThematicBreak],
     Field(discriminator="type"),
 ]
 
 
 # Union of all inline content types.
 Inline = Annotated[
-    Union[Cite, CiteGroup, Text, Emphasis, InlineCode, Strong, Subscript, Superscript],
+    Union[
+        Cite,
+        CiteGroup,
+        Text,
+        Emphasis,
+        CodeExpr,
+        InlineCode,
+        Strong,
+        Subscript,
+        Superscript,
+    ],
     Field(discriminator="type"),
 ]
 
@@ -336,6 +395,8 @@ Inline = Annotated[
 Cite.model_rebuild()
 CiteGroup.model_rebuild()
 Code.model_rebuild()
+CodeCell.model_rebuild()
+CodeExpr.model_rebuild()
 Document.model_rebuild()
 Emphasis.model_rebuild()
 Heading.model_rebuild()
@@ -354,6 +415,8 @@ __all__ = [
     "Cite",
     "CiteGroup",
     "Code",
+    "CodeCell",
+    "CodeExpr",
     "Document",
     "Emphasis",
     "Heading",

--- a/packages/oxa-types-rs/src/lib.rs
+++ b/packages/oxa-types-rs/src/lib.rs
@@ -109,6 +109,56 @@ pub struct Code {
     pub value: String,
 }
 
+/// An executable block of code that can produce outputs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeCell {
+    /// The type discriminator for CodeCell nodes.
+    pub r#type: MustBe!("CodeCell"),
+    /// A unique identifier for the node.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// A list of class names for styling or semantics.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classes: Option<Vec<String>>,
+    /// Arbitrary key-value data attached to the node.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    /// The source code to execute.
+    pub code: String,
+    /// The programming language identifier for the code.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Whether the source code is displayed to readers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isEchoed")]
+    pub is_echoed: Option<bool>,
+    /// Whether outputs are hidden from readers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "isHidden")]
+    pub is_hidden: Option<bool>,
+}
+
+/// An executable expression embedded within prose.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CodeExpr {
+    /// The type discriminator for CodeExpr nodes.
+    pub r#type: MustBe!("CodeExpr"),
+    /// A unique identifier for the node.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// A list of class names for styling or semantics.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classes: Option<Vec<String>>,
+    /// Arbitrary key-value data attached to the node.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    /// The expression to evaluate.
+    pub code: String,
+    /// The programming language identifier for the expression.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+}
+
 /// A document with metadata, title, and block content.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Document {
@@ -323,6 +373,7 @@ pub struct ThematicBreak {
 #[serde(untagged)]
 pub enum Block {
     Code(Code),
+    CodeCell(CodeCell),
     Heading(Heading),
     Paragraph(Paragraph),
     Reference(Reference),
@@ -337,6 +388,7 @@ pub enum Inline {
     CiteGroup(CiteGroup),
     Text(Text),
     Emphasis(Emphasis),
+    CodeExpr(CodeExpr),
     InlineCode(InlineCode),
     Strong(Strong),
     Subscript(Subscript),

--- a/packages/oxa-types-ts/src/index.ts
+++ b/packages/oxa-types-ts/src/index.ts
@@ -120,6 +120,74 @@ export interface Code {
 }
 
 /**
+ * An executable block of code that can produce outputs.
+ */
+export interface CodeCell {
+  /**
+   * The type discriminator for CodeCell nodes.
+   */
+  type: "CodeCell";
+  /**
+   * A unique identifier for the node.
+   */
+  id?: string;
+  /**
+   * A list of class names for styling or semantics.
+   */
+  classes?: string[];
+  /**
+   * Arbitrary key-value data attached to the node.
+   */
+  data?: Record<string, unknown>;
+  /**
+   * The source code to execute.
+   */
+  code: string;
+  /**
+   * The programming language identifier for the code.
+   */
+  language?: string;
+  /**
+   * Whether the source code is displayed to readers.
+   */
+  isEchoed?: boolean;
+  /**
+   * Whether outputs are hidden from readers.
+   */
+  isHidden?: boolean;
+}
+
+/**
+ * An executable expression embedded within prose.
+ */
+export interface CodeExpr {
+  /**
+   * The type discriminator for CodeExpr nodes.
+   */
+  type: "CodeExpr";
+  /**
+   * A unique identifier for the node.
+   */
+  id?: string;
+  /**
+   * A list of class names for styling or semantics.
+   */
+  classes?: string[];
+  /**
+   * Arbitrary key-value data attached to the node.
+   */
+  data?: Record<string, unknown>;
+  /**
+   * The expression to evaluate.
+   */
+  code: string;
+  /**
+   * The programming language identifier for the expression.
+   */
+  language?: string;
+}
+
+/**
  * A document with metadata, title, and block content.
  */
 export interface Document {
@@ -424,7 +492,13 @@ export interface ThematicBreak {
 /**
  * Union of all block content types.
  */
-export type Block = Code | Heading | Paragraph | Reference | ThematicBreak;
+export type Block =
+  | Code
+  | CodeCell
+  | Heading
+  | Paragraph
+  | Reference
+  | ThematicBreak;
 
 /**
  * Union of all inline content types.
@@ -434,6 +508,7 @@ export type Inline =
   | CiteGroup
   | Text
   | Emphasis
+  | CodeExpr
   | InlineCode
   | Strong
   | Subscript

--- a/schema/Block.yaml
+++ b/schema/Block.yaml
@@ -4,6 +4,7 @@ title: Block
 description: Union of all block content types.
 anyOf:
   - $ref: "./Code.yaml"
+  - $ref: "./CodeCell.yaml"
   - $ref: "./Heading.yaml"
   - $ref: "./Paragraph.yaml"
   - $ref: "./Reference.yaml"

--- a/schema/CodeCell.yaml
+++ b/schema/CodeCell.yaml
@@ -1,0 +1,38 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: CodeCell
+title: CodeCell
+description: An executable block of code that can produce outputs.
+type: object
+properties:
+  type:
+    description: The type discriminator for CodeCell nodes.
+    enum: [CodeCell]
+  id:
+    description: A unique identifier for the node.
+    type: string
+  classes:
+    description: A list of class names for styling or semantics.
+    type: array
+    items:
+      type: string
+  data:
+    description: Arbitrary key-value data attached to the node.
+    type: object
+    additionalProperties: true
+  code:
+    description: The source code to execute.
+    type: string
+  language:
+    description: The programming language identifier for the code.
+    type: string
+  isEchoed:
+    description: Whether the source code is displayed to readers.
+    type: boolean
+    default: false
+  isHidden:
+    description: Whether outputs are hidden from readers.
+    type: boolean
+    default: false
+required:
+  - type
+  - code

--- a/schema/CodeExpr.yaml
+++ b/schema/CodeExpr.yaml
@@ -1,0 +1,30 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: CodeExpr
+title: CodeExpr
+description: An executable expression embedded within prose.
+type: object
+properties:
+  type:
+    description: The type discriminator for CodeExpr nodes.
+    enum: [CodeExpr]
+  id:
+    description: A unique identifier for the node.
+    type: string
+  classes:
+    description: A list of class names for styling or semantics.
+    type: array
+    items:
+      type: string
+  data:
+    description: Arbitrary key-value data attached to the node.
+    type: object
+    additionalProperties: true
+  code:
+    description: The expression to evaluate.
+    type: string
+  language:
+    description: The programming language identifier for the expression.
+    type: string
+required:
+  - type
+  - code

--- a/schema/Inline.yaml
+++ b/schema/Inline.yaml
@@ -7,6 +7,7 @@ anyOf:
   - $ref: "./CiteGroup.yaml"
   - $ref: "./Text.yaml"
   - $ref: "./Emphasis.yaml"
+  - $ref: "./CodeExpr.yaml"
   - $ref: "./InlineCode.yaml"
   - $ref: "./Strong.yaml"
   - $ref: "./Subscript.yaml"

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -13,6 +13,9 @@
           "$ref": "#/definitions/Code"
         },
         {
+          "$ref": "#/definitions/CodeCell"
+        },
+        {
           "$ref": "#/definitions/Heading"
         },
         {
@@ -172,6 +175,88 @@
       },
       "required": ["type", "value"]
     },
+    "CodeCell": {
+      "title": "CodeCell",
+      "description": "An executable block of code that can produce outputs.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type discriminator for CodeCell nodes.",
+          "enum": ["CodeCell"]
+        },
+        "id": {
+          "description": "A unique identifier for the node.",
+          "type": "string"
+        },
+        "classes": {
+          "description": "A list of class names for styling or semantics.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "data": {
+          "description": "Arbitrary key-value data attached to the node.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "code": {
+          "description": "The source code to execute.",
+          "type": "string"
+        },
+        "language": {
+          "description": "The programming language identifier for the code.",
+          "type": "string"
+        },
+        "isEchoed": {
+          "description": "Whether the source code is displayed to readers.",
+          "type": "boolean",
+          "default": false
+        },
+        "isHidden": {
+          "description": "Whether outputs are hidden from readers.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": ["type", "code"]
+    },
+    "CodeExpr": {
+      "title": "CodeExpr",
+      "description": "An executable expression embedded within prose.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "The type discriminator for CodeExpr nodes.",
+          "enum": ["CodeExpr"]
+        },
+        "id": {
+          "description": "A unique identifier for the node.",
+          "type": "string"
+        },
+        "classes": {
+          "description": "A list of class names for styling or semantics.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "data": {
+          "description": "Arbitrary key-value data attached to the node.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "code": {
+          "description": "The expression to evaluate.",
+          "type": "string"
+        },
+        "language": {
+          "description": "The programming language identifier for the expression.",
+          "type": "string"
+        }
+      },
+      "required": ["type", "code"]
+    },
     "Document": {
       "title": "Document",
       "description": "A document with metadata, title, and block content.",
@@ -310,6 +395,9 @@
         },
         {
           "$ref": "#/definitions/Emphasis"
+        },
+        {
+          "$ref": "#/definitions/CodeExpr"
         },
         {
           "$ref": "#/definitions/InlineCode"


### PR DESCRIPTION
Implements https://github.com/oxa-dev/rfc/pull/4. 

Adds `CodeCell` and `CodeExpr` schemas, conformance cases, generated docs, language types, and ATProto lexicons. Wires executable code nodes through ATProto conversion and React default renderers, including inline source facet fields. Cover validation and conversion behavior for the new executable code nodes.